### PR TITLE
Removes the Cloud Servers GET / call to query versions

### DIFF
--- a/api-ref/src/docbkx/ch_servers.xml
+++ b/api-ref/src/docbkx/ch_servers.xml
@@ -9,7 +9,8 @@
     <title>Cloud Servers API v2</title>
     <para>Launch virtual machines from images or images stored on
         persistent volumes. API v1.1 is identical to API v2.</para>
-    <section xml:id="compute_versions">
+    <!--At Rackspace, we give a 403 error on this call, so comment out.-->
+    <!--<section xml:id="compute_versions">
         <title>Versions</title>
         <para>List versions and get information about a specific
             version of the API.</para>
@@ -23,7 +24,7 @@
                 <wadl:method href="#getVersionDetailsv2"/>
             </wadl:resource>
         </wadl:resources>
-    </section>
+    </section>-->
     <section xml:id="compute_extensions">
         <title>Extensions</title>
         <para>List all available extensions and gets details for a


### PR DESCRIPTION
Rackspace doesn't enable this for Cloud Servers.